### PR TITLE
Cleanup & Proper usage of NIO

### DIFF
--- a/src/main/java/net/hypixel/resourcepack/PackConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/PackConverter.java
@@ -63,7 +63,9 @@ public class PackConverter {
 
                         System.out.println("  Running Converters");
                         for (Converter converter : converters.values()) {
-                            if (PackConverter.DEBUG) System.out.println("    Running " + converter.getClass().getSimpleName());
+                            if (PackConverter.DEBUG) {
+                                System.out.println("    Running " + converter.getClass().getSimpleName());
+                            }
                             converter.convert(pack);
                         }
 

--- a/src/main/java/net/hypixel/resourcepack/impl/AnimationConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/AnimationConverter.java
@@ -7,12 +7,10 @@ import net.hypixel.resourcepack.PackConverter;
 import net.hypixel.resourcepack.Util;
 import net.hypixel.resourcepack.pack.Pack;
 
-import java.io.File;
 import java.io.IOException;
-import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Collections;
 
 public class AnimationConverter extends Converter {
 
@@ -22,13 +20,15 @@ public class AnimationConverter extends Converter {
 
     @Override
     public void convert(Pack pack) throws IOException {
-        fixAnimations(pack.getWorkingPath().resolve("assets" + File.separator + "minecraft" + File.separator + "textures" + File.separator + "block"));
-        fixAnimations(pack.getWorkingPath().resolve("assets" + File.separator + "minecraft" + File.separator + "textures" + File.separator + "item"));
+        Path texturesPath = pack.getMinecraftPath().resolve("textures");
+        fixAnimations(texturesPath.resolve("block"));
+        fixAnimations(texturesPath.resolve("item"));
     }
 
     protected void fixAnimations(Path animations) throws IOException {
-        if (!animations.toFile().exists()) return;
-
+        if (!Files.exists(animations)) {
+            return;
+        }
         Files.list(animations)
                 .filter(file -> file.toString().endsWith(".png.mcmeta"))
                 .forEach(file -> {
@@ -48,9 +48,10 @@ public class AnimationConverter extends Converter {
                         }
 
                         if (anyChanges) {
-                            Files.write(file, Collections.singleton(packConverter.getGson().toJson(json)), Charset.forName("UTF-8"));
-
-                            if (PackConverter.DEBUG) System.out.println("      Converted " + file.getFileName());
+                            Files.write(file, packConverter.getGson().toJson(json).getBytes(StandardCharsets.UTF_8));
+                            if (PackConverter.DEBUG) {
+                                System.out.println("      Converted " + file.getFileName());
+                            }
                         }
                     } catch (IOException e) {
                         Util.propagate(e);

--- a/src/main/java/net/hypixel/resourcepack/impl/BlockStateConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/BlockStateConverter.java
@@ -11,6 +11,7 @@ import net.hypixel.resourcepack.pack.Pack;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -24,9 +25,11 @@ public class BlockStateConverter extends Converter {
 
     @Override
     public void convert(Pack pack) throws IOException {
-        Path states = pack.getWorkingPath().resolve("assets" + File.separator + "minecraft" + File.separator + "blockstates");
-        if (!states.toFile().exists()) return;
-
+        Path states = pack.getMinecraftPath()
+                .resolve("blockstates");
+        if (!Files.exists(states)) {
+            return;
+        }
         Files.list(states)
                 .filter(file -> file.toString().endsWith(".json"))
                 .forEach(file -> {
@@ -68,9 +71,10 @@ public class BlockStateConverter extends Converter {
                         }
 
                         if (anyChanges) {
-                            Files.write(file, Collections.singleton(packConverter.getGson().toJson(json)), Charset.forName("UTF-8"));
-
-                            if (PackConverter.DEBUG) System.out.println("      Converted " + file.getFileName());
+                            Files.write(file, packConverter.getGson().toJson(json).getBytes(StandardCharsets.UTF_8));
+                            if (PackConverter.DEBUG) {
+                                System.out.println("      Converted " + file.getFileName());
+                            }
                         }
                     } catch (IOException e) {
                         Util.propagate(e);

--- a/src/main/java/net/hypixel/resourcepack/impl/MapIconConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/MapIconConverter.java
@@ -8,8 +8,8 @@ import net.hypixel.resourcepack.pack.Pack;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.Map;
@@ -20,7 +20,6 @@ public class MapIconConverter extends Converter {
 
     public MapIconConverter(PackConverter packConverter) {
         super(packConverter);
-
         mapping.put(pack(0, 0), pack(0, 0));
         mapping.put(pack(8, 0), pack(8, 0));
         mapping.put(pack(16, 0), pack(16, 0));
@@ -35,30 +34,31 @@ public class MapIconConverter extends Converter {
 
     @Override
     public void convert(Pack pack) throws IOException {
-        Path imagePath = pack.getWorkingPath().resolve("assets" + File.separator + "minecraft" + File.separator + "textures" + File.separator + "map" + File.separator + "map_icons.png");
-        if (!imagePath.toFile().exists()) return;
-
-        BufferedImage newImage = Util.readImageResource("/map_icons.png");
-        if (newImage == null) throw new NullPointerException();
-        Graphics2D g2d = (Graphics2D) newImage.getGraphics();
-
-        BufferedImage image = ImageIO.read(imagePath.toFile());
-        int scale = image.getWidth() / 32;
-
-        for (int x = 0; x <= 32 - 8; x += 8) {
-            for (int y = 0; y <= 32 - 8; y += 8) {
-                Long mapped = mapping.get(pack(x, y));
-                if (mapped == null) continue;
-
-                int newX = (int) (mapped >> 32);
-                int newY = (int) (long) mapped;
-                System.out.println("      Mapping " + x + "," + y + " to " + newX + "," + newY);
-
-                g2d.drawImage(image.getSubimage(x * scale, y * scale, 8 * scale, 8 * scale), newX * scale, newY * scale, null);
+        Path imagePath = pack.getMinecraftPath()
+                .resolve("textures")
+                .resolve("map")
+                .resolve("map_icons.png");
+        if (Files.exists(imagePath)) {
+            BufferedImage newImage = Util.readImageResource("/map_icons.png");
+            if (newImage == null) {
+                throw new NullPointerException();
             }
+            Graphics2D g2d = (Graphics2D) newImage.getGraphics();
+            BufferedImage image = ImageIO.read(Files.newInputStream(imagePath));
+            int scale = image.getWidth() / 32;
+            for (int x = 0; x <= 32 - 8; x += 8) {
+                for (int y = 0; y <= 32 - 8; y += 8) {
+                    Long mapped = mapping.get(pack(x, y));
+                    if (mapped != null) {
+                        int newX = (int) (mapped >> 32);
+                        int newY = (int) (long) mapped;
+                        System.out.println("      Mapping " + x + "," + y + " to " + newX + "," + newY);
+                        g2d.drawImage(image.getSubimage(x * scale, y * scale, 8 * scale, 8 * scale), newX * scale, newY * scale, null);
+                    }
+                }
+            }
+            ImageIO.write(newImage, "png", imagePath.toFile());
         }
-
-        ImageIO.write(newImage, "png", imagePath.toFile());
     }
 
     protected long pack(int x, int y) {

--- a/src/main/java/net/hypixel/resourcepack/impl/PackMetaConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/PackMetaConverter.java
@@ -8,6 +8,7 @@ import net.hypixel.resourcepack.pack.Pack;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -21,22 +22,28 @@ public class PackMetaConverter extends Converter {
     @Override
     public void convert(Pack pack) throws IOException {
         Path file = pack.getWorkingPath().resolve("pack.mcmeta");
-        if (!file.toFile().exists()) return;
-
-        JsonObject json = Util.readJson(packConverter.getGson(), file);
-        {
-            JsonObject meta = json.getAsJsonObject("meta");
-            if (meta == null) meta = new JsonObject();
-            meta.addProperty("game_version", "1.13");
-            json.add("meta", meta);
+        if (Files.exists(file)) {
+            JsonObject json = Util.readJson(packConverter.getGson(), file);
+            {
+                JsonObject meta = json.getAsJsonObject("meta");
+                if (meta == null) {
+                    meta = new JsonObject();
+                }
+                meta.addProperty("game_version", "1.13");
+                json.add("meta", meta);
+            }
+            {
+                JsonObject packObject = json.getAsJsonObject("pack");
+                if (packObject == null) {
+                    packObject = new JsonObject();
+                }
+                packObject.addProperty("pack_format", 4);
+                json.add("pack", packObject);
+            }
+            Files.write(file, packConverter.getGson()
+                    .toJson(json)
+                    .getBytes(StandardCharsets.UTF_8)
+            );
         }
-        {
-            JsonObject packObject = json.getAsJsonObject("pack");
-            if (packObject == null) packObject = new JsonObject();
-            packObject.addProperty("pack_format", 4);
-            json.add("pack", packObject);
-        }
-
-        Files.write(file, Collections.singleton(packConverter.getGson().toJson(json)), Charset.forName("UTF-8"));
     }
 }

--- a/src/main/java/net/hypixel/resourcepack/impl/ParticleConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/ParticleConverter.java
@@ -7,8 +7,8 @@ import net.hypixel.resourcepack.pack.Pack;
 import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.image.BufferedImage;
-import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ParticleConverter extends Converter {
@@ -19,20 +19,21 @@ public class ParticleConverter extends Converter {
 
     @Override
     public void convert(Pack pack) throws IOException {
-        Path imagePath = pack.getWorkingPath().resolve("assets" + File.separator + "minecraft" + File.separator + "textures" + File.separator + "particle" + File.separator + "particles.png");
-        if (!imagePath.toFile().exists()) return;
-
-        BufferedImage image = ImageIO.read(imagePath.toFile());
-
-        // TODO check how higher resolution will handle this.
-        if (image.getWidth() == 128 && image.getHeight() == 128) {
-            // make a new bigger image and just paste the existing on in the top left corner
-            BufferedImage newImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_ARGB);
-            Graphics2D g2d = (Graphics2D) newImage.getGraphics();
-            g2d.drawImage(image, 0, 0, null);
-
-            // save the new one
-            ImageIO.write(newImage, "png", imagePath.toFile());
+        Path imagePath = pack.getMinecraftPath()
+                .resolve("textures")
+                .resolve("particle")
+                .resolve("particles.png");
+        if (Files.exists(imagePath)) {
+            BufferedImage image = ImageIO.read(Files.newInputStream(imagePath));
+            // TODO check how higher resolution will handle this.
+            if (image.getWidth() == 128 && image.getHeight() == 128) {
+                // make a new bigger image and just paste the existing on in the top left corner
+                BufferedImage newImage = new BufferedImage(256, 256, BufferedImage.TYPE_INT_ARGB);
+                Graphics2D g2d = (Graphics2D) newImage.getGraphics();
+                g2d.drawImage(image, 0, 0, null);
+                // save the new one
+                ImageIO.write(newImage, "png", Files.newOutputStream(imagePath));
+            }
         }
     }
 

--- a/src/main/java/net/hypixel/resourcepack/impl/SpacesConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/SpacesConverter.java
@@ -2,7 +2,6 @@ package net.hypixel.resourcepack.impl;
 
 import net.hypixel.resourcepack.Converter;
 import net.hypixel.resourcepack.PackConverter;
-import net.hypixel.resourcepack.Util;
 import net.hypixel.resourcepack.pack.Pack;
 
 import java.io.IOException;
@@ -20,16 +19,20 @@ public class SpacesConverter extends Converter {
         Path assets = pack.getWorkingPath().resolve("assets");
         if (!assets.toFile().exists()) return;
 
-        Files.walk(assets).forEach(path -> {
-            if (!path.getFileName().toString().contains(" ")) return;
-
-            String noSpaces = path.getFileName().toString().replaceAll(" ", "_");
-            Boolean ret = Util.renameFile(path, noSpaces);
-            if (ret == null) return;
-            if (ret && PackConverter.DEBUG) {
-                System.out.println("      Renamed: " + path.getFileName().toString() + "->" + noSpaces);
-            } else if (!ret) {
-                System.err.println("      Failed to rename: " + path.getFileName().toString() + "->" + noSpaces);
+        Files.walk(assets).forEach(file -> {
+            String fileName = file.getFileName().toString();
+            if (fileName.contains(" ")) {
+                String noSpaces = fileName.replaceAll(" ", "_");
+                try {
+                    if (Files.exists(file)) {
+                        Files.move(file, file.getParent().resolve(noSpaces));
+                        if (PackConverter.DEBUG) {
+                            System.out.println("      Renamed: " + file.getFileName().toString() + "->" + noSpaces);
+                        }
+                    }
+                } catch (IOException e) {
+                    System.err.println("      Failed to rename: " + file.getFileName().toString() + "->" + noSpaces);
+                }
             }
         });
     }

--- a/src/main/java/net/hypixel/resourcepack/pack/Pack.java
+++ b/src/main/java/net/hypixel/resourcepack/pack/Pack.java
@@ -3,17 +3,22 @@ package net.hypixel.resourcepack.pack;
 import net.hypixel.resourcepack.Util;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class Pack {
 
-    protected static final String CONVERTED_SUFFIX = "_converted_1_13";
+    private static final String CONVERTED_SUFFIX = "_converted_1_13";
 
     protected Path path;
+    private final Path workingPath;
+    private final Path minecraftPath;
     protected Handler handler;
 
     protected Pack(Path path) {
         this.path = path;
+        this.workingPath = path.getParent().resolve(getFileName() + CONVERTED_SUFFIX);
+        this.minecraftPath = workingPath.resolve("assets").resolve("minecraft");
         this.handler = createHandler();
     }
 
@@ -42,7 +47,11 @@ public class Pack {
     }
 
     public Path getWorkingPath() {
-        return path.getParent().resolve(getFileName() + CONVERTED_SUFFIX);
+        return workingPath;
+    }
+
+    public Path getMinecraftPath() {
+        return minecraftPath;
     }
 
     public String getFileName() {
@@ -65,13 +74,13 @@ public class Pack {
         }
 
         public void setup() throws IOException {
-            if (pack.getWorkingPath().toFile().exists()) {
+            Path workingPath = pack.getWorkingPath();
+            if (Files.exists(workingPath)) {
                 System.out.println("  Deleting existing conversion");
-                Util.deleteDirectoryAndContents(pack.getWorkingPath());
+                Util.deleteDirectoryAndContents(workingPath);
             }
-
             System.out.println("  Copying existing pack");
-            Util.copyDir(pack.getOriginalPath(), pack.getWorkingPath());
+            Util.copyDir(pack.getOriginalPath(), workingPath);
         }
 
         public void finish() throws IOException {

--- a/src/main/java/net/hypixel/resourcepack/pack/ZipPack.java
+++ b/src/main/java/net/hypixel/resourcepack/pack/ZipPack.java
@@ -6,6 +6,7 @@ import net.lingala.zip4j.exception.ZipException;
 import net.lingala.zip4j.model.ZipParameters;
 
 import java.io.IOException;
+import java.nio.file.Files;
 import java.nio.file.Path;
 
 public class ZipPack extends Pack {
@@ -36,22 +37,29 @@ public class ZipPack extends Pack {
 
         @Override
         public void setup() throws IOException {
-            if (pack.getWorkingPath().toFile().exists()) {
+            Path workingPath = pack.getWorkingPath();
+            if (Files.exists(workingPath)) {
                 System.out.println("  Deleting existing conversion");
-                Util.deleteDirectoryAndContents(pack.getWorkingPath());
+                Util.deleteDirectoryAndContents(workingPath);
             }
 
             Path convertedZipPath = getConvertedZipPath();
-            if (convertedZipPath.toFile().exists()) {
+            if (Files.exists(convertedZipPath)) {
                 System.out.println("  Deleting existing conversion zip");
-                convertedZipPath.toFile().delete();
+                try {
+                    Files.delete(convertedZipPath);
+                } catch (IOException e) {
+                    System.err.println("  Failed to delete existing conversion zip: " + e.getMessage());
+                }
             }
-
-            pack.getWorkingPath().toFile().mkdir();
-
+            try {
+                Files.createDirectory(workingPath);
+            }catch (IOException e) {
+                System.err.println("  Failed to create working path: " + e.getMessage());
+            }
             try {
                 ZipFile zipFile = new ZipFile(pack.getOriginalPath().toFile());
-                zipFile.extractAll(pack.getWorkingPath().toString());
+                zipFile.extractAll(workingPath.toString());
             } catch (ZipException e) {
                 Util.propagate(e);
             }


### PR DESCRIPTION
Cleaned up the files making them more readable 
(Slimmed down path resolutions and added method getMinecraftPath as an alternative to getWorkingPath which replaces a lot of reused calls)

Moved getWorkingPath code to the field workingPath
in net.hypixel.resourcepack.pack.Pack so that it is only created once instead of re-creating it every call (this was also done for the getMinecraftPath method)

Fixed incorrect usage of nio Paths being converted to io files then accessed instead of using the Files interface for nio. This also includes the use of Collections.singleton when writing the file as this can be replaced with a call to getBytes(Charset)