### PR TITLE
Relocate armor model textures in 1.21.2

### DIFF
--- a/src/main/java/net/hypixel/resourcepack/MinecraftVersion.java
+++ b/src/main/java/net/hypixel/resourcepack/MinecraftVersion.java
@@ -8,6 +8,7 @@ public enum MinecraftVersion {
     v1_13("1.13", 4),
     v1_14("1.14", 4),
     v1_20("1.20", 15),
+    v1_21_2("1.21.2", 42)
     ;
 
     private static final Map<String, MinecraftVersion> BY_NAME;

--- a/src/main/java/net/hypixel/resourcepack/PackConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/PackConverter.java
@@ -53,6 +53,7 @@ public class PackConverter {
         this.registerConverter(new MapIconConverter(this));
         this.registerConverter(new PaintingConverter(this));
         this.registerConverter(new UnicodeFontConverter(this));
+        this.registerConverter(new ArmorModelConverter(this));
     }
 
     public void registerConverter(Converter converter) {

--- a/src/main/java/net/hypixel/resourcepack/Util.java
+++ b/src/main/java/net/hypixel/resourcepack/Util.java
@@ -11,11 +11,20 @@ import java.io.*;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.Comparator;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
 
 public final class Util {
 
     private Util() {
         throw new UnsupportedOperationException("This class cannot be instantiated");
+    }
+
+    public static <K, V, M extends Map<K, V>> M createMap(Supplier<M> mapSupplier, Consumer<M> initializer) {
+        M map = mapSupplier.get();
+        initializer.accept(map);
+        return map;
     }
 
     public static void copyDir(Path src, Path dest) throws IOException {

--- a/src/main/java/net/hypixel/resourcepack/impl/ArmorModelConverter.java
+++ b/src/main/java/net/hypixel/resourcepack/impl/ArmorModelConverter.java
@@ -1,0 +1,99 @@
+package net.hypixel.resourcepack.impl;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+import net.hypixel.resourcepack.Converter;
+import net.hypixel.resourcepack.MinecraftVersion;
+import net.hypixel.resourcepack.PackConverter;
+import net.hypixel.resourcepack.Util;
+import net.hypixel.resourcepack.pack.Pack;
+
+public class ArmorModelConverter extends Converter {
+
+    private static final Map<String, String> ARMOR_TEXTURES = Util.createMap(HashMap::new, map -> {
+            map.put("chainmail_layer_1", "chainmail");
+            map.put("diamond_layer_1", "diamond");
+            map.put("gold_layer_1", "gold");
+            map.put("iron_layer_1", "iron");
+            map.put("leather_layer_1", "leather");
+            map.put("leather_layer_1_overlay", "leather_overlay");
+    });
+
+    private static final Map<String, String> LEGGING_TEXTURES = Util.createMap(HashMap::new, map -> {
+            map.put("chainmail_layer_2", "chainmail");
+            map.put("diamond_layer_2", "diamond");
+            map.put("gold_layer_2", "gold");
+            map.put("iron_layer_2", "iron");
+            map.put("leather_layer_2", "leather");
+            map.put("leather_layer_2_overlay", "leather_overlay");
+    });
+
+    public ArmorModelConverter(PackConverter packConverter) {
+        super(packConverter);
+    }
+
+    @Override
+    public MinecraftVersion getVersion() {
+        return MinecraftVersion.v1_21_2;
+    }
+
+    @Override
+    public void convert(Pack pack) throws IOException {
+        Path legacyArmorModelDirectory = pack.getWorkingPath().resolve("assets/minecraft/textures/models/armor/");
+        if (Files.notExists(legacyArmorModelDirectory)) {
+            return;
+        }
+
+        Path texturesEquipmentDirectory = pack.getWorkingPath().resolve("assets/minecraft/textures/entity/equipment/");
+        Path texturesHumanoidDirectory = texturesEquipmentDirectory.resolve("humanoid/");
+        Path texturesHumanoidLeggingsDirectory = texturesEquipmentDirectory.resolve("humanoid_leggings/");
+
+        this.convertTextures(pack, legacyArmorModelDirectory, ARMOR_TEXTURES, texturesHumanoidDirectory);
+        this.convertTextures(pack, legacyArmorModelDirectory, LEGGING_TEXTURES, texturesHumanoidLeggingsDirectory);
+    }
+
+    private void convertTextures(Pack pack, Path legacyArmorModelDirectory, Map<String, String> textureMapping, Path targetDirectory) throws IOException {
+        if (Files.notExists(legacyArmorModelDirectory)) {
+            return;
+        }
+
+        boolean createdDirectory = false;
+
+        for (Map.Entry<String, String> textureEntry : textureMapping.entrySet()) {
+            String legacyTextureName = textureEntry.getKey() + ".png";
+            Path legacyTexturePath = legacyArmorModelDirectory.resolve(legacyTextureName);
+            if (Files.notExists(legacyTexturePath)) {
+                continue;
+            }
+
+            if (!createdDirectory) {
+                createdDirectory = true;
+                Files.createDirectories(targetDirectory);
+                System.out.println("      Created directory " + pack.getWorkingPath().relativize(targetDirectory));
+            }
+
+            String modernTextureName = textureEntry.getValue() + ".png";
+            Path modernTexturePath = targetDirectory.resolve(modernTextureName);
+
+            Path relativeLegacyDirectory = pack.getWorkingPath().relativize(legacyTexturePath);
+            Path relativeModernDirectory = pack.getWorkingPath().relativize(modernTexturePath);
+            if (Files.exists(modernTexturePath)) {
+                System.err.println("      Would have moved " + relativeLegacyDirectory + " to " + relativeModernDirectory + " but a file already exists!");
+                continue;
+            }
+
+            Files.move(legacyTexturePath, modernTexturePath);
+            System.out.println("      Moved " + relativeLegacyDirectory + " to " + relativeModernDirectory);
+        }
+
+        if (Files.list(legacyArmorModelDirectory).count() == 0) {
+            Files.deleteIfExists(legacyArmorModelDirectory);
+            System.out.println("      Deleting now empty directory " + pack.getWorkingPath().relativize(legacyArmorModelDirectory));
+        }
+    }
+
+}


### PR DESCRIPTION
This moves the armour models that were previously defined in `textures/models/armor/`, but were moved in 1.21.2 to `textures/entity/equipment/humanoid` and `textures/entity/equipment/humanoid_leggings` and renamed to their simpler counterparts.

This is just a simple move and rename.